### PR TITLE
set the fold parameters locally for this filetype

### DIFF
--- a/ftplugin/ipynb.vim
+++ b/ftplugin/ipynb.vim
@@ -17,10 +17,10 @@ endfunction
 
 " Fold python's input and output cells using marker
 " (you should not change the folding method!)
-set foldmethod=marker
-set foldmarker=```{.,```
+setlocal foldmethod=marker
+setlocal foldmarker=```{.,```
 
-set foldtext=CellFoldingNaming()
+setlocal foldtext=CellFoldingNaming()
 
 " If deoplete present try to load custom jedi source
 if exists('g:loaded_deoplete')


### PR DESCRIPTION
You are currently overriding the defaults parameter for folding.
This fix does not change the global behavior of this plugin but it limit side effects.

For example, in my vimrc I use the default foldmarkers and when I wanted to edit it on a split, (beside a notebook) none of my folds were recognized.